### PR TITLE
Install latest ca-certificates

### DIFF
--- a/setup/roles/cri-o/tasks/main.yaml
+++ b/setup/roles/cri-o/tasks/main.yaml
@@ -1,4 +1,11 @@
 ---
+- name: prerequisites
+  ansible.builtin.apt:
+    name:
+      - ca-certificates
+    state: latest
+    update_cache: yes
+
 - name: gpg key
   ansible.builtin.apt_key:
     url: "{{ crio_repo }}/{{ crio_os }}/Release.key"

--- a/setup/roles/cri-o/tasks/main.yaml
+++ b/setup/roles/cri-o/tasks/main.yaml
@@ -1,11 +1,4 @@
 ---
-- name: prerequisites
-  ansible.builtin.apt:
-    name:
-      - ca-certificates
-    state: latest
-    update_cache: yes
-
 - name: gpg key
   ansible.builtin.apt_key:
     url: "{{ crio_repo }}/{{ crio_os }}/Release.key"

--- a/setup/roles/tools/tasks/main.yaml
+++ b/setup/roles/tools/tasks/main.yaml
@@ -1,8 +1,10 @@
 ---
 - name: install
   apt:
-    name: 
+    name:
       - jq
       - tmux
       - unzip
+      - ca-certificates
+    state: latest
     update_cache: yes


### PR DESCRIPTION
Fixes: https://github.com/book-of-kubernetes/examples/issues/2

If you are not running the optional extra playbook, run the following commands when directly on the host machine (not inside a docker container):

```bash
sudo apt-get update
sudo apt-get install ca-certificates
```