### PR TITLE
Use stress:stable

### DIFF
--- a/chapter-03/files/co-clim.yaml
+++ b/chapter-03/files/co-clim.yaml
@@ -2,7 +2,7 @@
 metadata:
   name: stress1
 image:
-  image: docker.io/bookofkubernetes/stress:latest
+  image: docker.io/bookofkubernetes/stress:stable
 args:
   - "--cpu"
   - "1"

--- a/chapter-03/files/co-mlim.yaml
+++ b/chapter-03/files/co-mlim.yaml
@@ -2,7 +2,7 @@
 metadata:
   name: stress2
 image:
-  image: docker.io/bookofkubernetes/stress:latest
+  image: docker.io/bookofkubernetes/stress:stable
 args:
   - "--vm"
   - "1"

--- a/chapter-03/files/co-nolim.yaml
+++ b/chapter-03/files/co-nolim.yaml
@@ -2,7 +2,7 @@
 metadata:
   name: stress
 image:
-  image: docker.io/bookofkubernetes/stress:latest
+  image: docker.io/bookofkubernetes/stress:stable
 args:
   - "--cpu"
   - "1"


### PR DESCRIPTION
Example in chapter 3 installs `stress:stable` with:

```
crictl pull docker.io/bookofkubernetes/stress:stable
```

Using these `yaml` files would result in:

```
FATA[0000] creating container: rpc error: code = Unknown desc = image not known 
```