### PR TITLE
Corrected URL for the todo app

### DIFF
--- a/chapter-01/playbook.yaml
+++ b/chapter-01/playbook.yaml
@@ -9,8 +9,8 @@
 - hosts: aws_ec2
   tasks:
     - debug:
-        msg: "Once your Kubernetes cluster is up, you can access the todo application at http://{{ inventory_hostname }}/todo"
+        msg: "Once your Kubernetes cluster is up, you can access the todo application at http://{{ inventory_hostname }}/todo/"
 - hosts: vagrant
   tasks:
     - debug:
-        msg: "Once your Kubernetes cluster is up, you can access the todo application at http://localhost:48080/todo"
+        msg: "Once your Kubernetes cluster is up, you can access the todo application at http://localhost:48080/todo/"


### PR DESCRIPTION
This resolves a small issue with the URL provided by Ansible causing a bad gateway error.

Fixes #6 