### PR TITLE
update calico manifest URL

### DIFF
--- a/setup/roles/k8s/tasks/install.yaml
+++ b/setup/roles/k8s/tasks/install.yaml
@@ -104,7 +104,7 @@
 
 - name: download calico operator
   ansible.builtin.get_url:
-    url: https://docs.projectcalico.org/archive/v{{ calico_version }}/manifests/tigera-operator.yaml
+    url: https://projectcalico.docs.tigera.io/archive/v{{ calico_version }}/manifests/tigera-operator.yaml
     dest: /etc/kubernetes/components/tigera-operator.yaml
     mode: '0644'
   when: 

--- a/setup/roles/k8s/templates/k8s-ver.j2
+++ b/setup/roles/k8s/templates/k8s-ver.j2
@@ -1,5 +1,5 @@
 export K8SV="{{ k8s_version }}-*"
-export calico_url="https://docs.projectcalico.org/archive/v{{ calico_version }}/manifests/tigera-operator.yaml"
+export calico_url="https://projectcalico.docs.tigera.io/archive/v{{ calico_version }}/manifests/tigera-operator.yaml"
 export longhorn_url="https://raw.githubusercontent.com/longhorn/longhorn/v{{ k8s_longhorn_version }}/deploy/longhorn.yaml"
 export metrics_url="https://github.com/kubernetes-sigs/metrics-server/releases/download/metrics-server-helm-chart-{{ metrics_server_version }}/components.yaml"
 export ingress_url="https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v{{ ingress_version }}/deploy/static/provider/cloud/deploy.yaml"


### PR DESCRIPTION
The former URL returned a 404. The [documentation](https://docs.tigera.io/archive/v3.22/getting-started/kubernetes/quickstart) now refers a different URL.

fixes #20 