### PR TITLE
Update default aws_ubuntu_image

### DIFF
--- a/setup/roles/aws-instances/defaults/main.yaml
+++ b/setup/roles/aws-instances/defaults/main.yaml
@@ -6,7 +6,7 @@ aws_k8s_pod_cidr: 172.31.0.0/16
 aws_k8s_svc_cidr: 10.96.0.0/12
 aws_key: aws_ansible_k8s
 aws_ubuntu_owner: "099720109477"
-aws_ubuntu_image: "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210223"
+aws_ubuntu_image: "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"
 aws_k8s_teardown: false
 aws_k8s_delete: false
 aws_k8s_ssh_dir: "../sshkeys"


### PR DESCRIPTION
The previously specified image "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210223" has become unavailable (possibly due to auto timeout after 2 years). It might be better to just use a wildcard instead of a specific timestamped version for a more robust default setting.