### PR TITLE
fix broken conditional in aws setup

### DIFF
--- a/setup/roles/aws-instances/tasks/setup.yaml
+++ b/setup/roles/aws-instances/tasks/setup.yaml
@@ -170,7 +170,7 @@
 - name: fetch host keys
   ansible.builtin.shell: aws ec2 get-console-output --region {{ aws_region }} --instance-id {{ item[2] }} --output text|sed -n 's/ecdsa-sha2-nistp256 \([^ ]*\).*/\1/p'
   register: aws_ec2_host_keys
-  until: aws_ec2_host_keys.stdout|length
+  until: aws_ec2_host_keys.stdout|length > 0
   delay: 30
   retries: 30
   with_list: "{{ aws_ec2_instance_data }}"


### PR DESCRIPTION
Since Ansible 2.19, implicit boolean conversions result in terminating errors. This change makes the conditional explicit, resolving this issue.

Running `ansible-playbook setup-setup.yaml` will result in an error like:
```
[ERROR]: Task failed: Conditional result (True) was derived from value of type 'int' at '.../examples/setup/roles/aws-instances/tasks/setup.yaml:173:10'. Conditionals must have a boolean result.
```

Tested on Ansible 2.20.0

Ref: https://docs.ansible.com/projects/ansible/latest/porting_guides/porting_guide_core_2.19.html#broken-conditionals