### PR TITLE
Update postgres operator image versions to v1.9.0

### DIFF
--- a/setup/roles/k8s/templates/postgres/operatorconfiguration.crd.yaml.j2
+++ b/setup/roles/k8s/templates/postgres/operatorconfiguration.crd.yaml.j2
@@ -448,7 +448,7 @@ spec:
                 properties:
                   logical_backup_docker_image:
                     type: string
-                    default: "registry.opensource.zalan.do/acid/logical-backup:v1.7.1"
+                    default: "registry.opensource.zalan.do/acid/logical-backup:v1.9.0"
                   logical_backup_google_application_credentials:
                     type: string
                   logical_backup_job_prefix:

--- a/setup/roles/k8s/templates/postgres/postgres-operator.yaml.j2
+++ b/setup/roles/k8s/templates/postgres/postgres-operator.yaml.j2
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: postgres-operator
       containers:
       - name: postgres-operator
-        image: registry.opensource.zalan.do/acid/postgres-operator:v1.7.1
+        image: registry.opensource.zalan.do/acid/postgres-operator:v1.9.0
         imagePullPolicy: IfNotPresent
         resources:
           requests:

--- a/setup/roles/k8s/templates/postgres/postgresql-operator-default-configuration.yaml.j2
+++ b/setup/roles/k8s/templates/postgres/postgresql-operator-default-configuration.yaml.j2
@@ -68,7 +68,7 @@ configuration:
     master_dns_name_format: "{cluster}.{team}.{hostedzone}"
     replica_dns_name_format: "{cluster}-repl.{team}.{hostedzone}"
   logical_backup:
-    logical_backup_docker_image: "registry.opensource.zalan.do/acid/logical-backup:v1.7.1"
+    logical_backup_docker_image: "registry.opensource.zalan.do/acid/logical-backup:v1.9.0"
     logical_backup_job_prefix: "logical-backup-"
     logical_backup_provider: "s3"
     logical_backup_s3_bucket: "my-bucket-url"


### PR DESCRIPTION
v1.7.1 of the postgres operator images caused the following deployment errors:

```bash
time="2026-04-15T13:20:43Z" level=info msg="secrets have been successfully created" cluster-name=todo/todo-db pkg=cluster worker=0
time="2026-04-15T13:20:43Z" level=error msg="could not create cluster: could not create pod disruption budget: the server could not find the requested resource" cluster-name=todo/todo-db pkg=controller worker=0
E0415 13:20:50.003246       1 reflector.go:138] pkg/controller/controller.go:477: Failed to watch *v1.PostgresTeam: failed to list *v1.PostgresTeam: the server could not find the requested resource (get postgresteams.acid.zalan.do)
```

After updating to v1.9.0 and redeploying the vagrant cluster, no errors occurred and full stand up took about 10 minutes.